### PR TITLE
fix password copy button in listings

### DIFF
--- a/js/copy-to-clipboard.js
+++ b/js/copy-to-clipboard.js
@@ -1,3 +1,4 @@
 $(function() {
     new ZeroClipboard($('.copy-to-clipboard'));
+    $("a.copy-to-clipboard").click(function(e){e.preventDefault();});
 });


### PR DESCRIPTION
In listings the password copy button didn't seem to do anything except send you back to the top of the page. Adding e.preventDefault() fixes this.